### PR TITLE
pass offset and duration params through BufferAudioObject.start to AudioBufferSourceNode.start

### DIFF
--- a/js/soundstage.objects.js
+++ b/js/soundstage.objects.js
@@ -3,7 +3,7 @@
 
 	var Soundstage = window.Soundstage;
 	var assign  = Object.assign;
-	
+
 	var cache = [];
 	var defaults = {};
 	var automation = {
@@ -210,7 +210,7 @@
 		function end(e) {
 			var node = e.target;
 			var i = nodes.indexOf(node);
-			
+
 			if (i > -1) { nodes.splice(i, 1); }
 			node.disconnect();
 			detuneNode.disconnect(node.detune);
@@ -250,7 +250,7 @@
 
 		this.noteCenter = 69; // A4
 
-		this.start = function(time, number) {
+		this.start = function(time, offset, duration, number) {
 			if (!buffer) { return this; }
 
 			var node = audio.createBufferSource();
@@ -266,7 +266,7 @@
 			node.loopEnd = this.loopEnd;
 			node.connect(outputNode);
 			node.onended = end;
-			node.start(time || 0);
+			node.start(time || 0, offset, duration);
 			nodes.push(node);
 			return this;
 		};


### PR DESCRIPTION
Fixes #19 

Wasn't sure how you would want the params passed, so I just stuck with matching the Web Audio API
